### PR TITLE
[~] updated version to 1.1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Spigot plugin that allows you to place "wires".
 
 ![Preview](https://saharnooby.me/download/preview.png?uuid=51da1969-48a3-42ef-82c1-6488a15af590)
 
+Download: [GitHub Releases](https://github.com/saharNooby/lead-wires/releases)
+
 [SpigotMC plugin page](https://www.spigotmc.org/resources/leadwires.76515/)
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Then, you need to add the plugin as a Maven dependency:
 <dependency>
     <groupId>me.saharnooby.plugins</groupId>
     <artifactId>lead-wires</artifactId>
-    <version>1.1.10</version>
+    <version>1.1.11</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.saharnooby.plugins</groupId>
     <artifactId>lead-wires</artifactId>
-    <version>1.1.10</version>
+    <version>1.1.11</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/saharnooby/plugins/leadwires/chunk/LoadedChunkTracker.java
+++ b/src/main/java/me/saharnooby/plugins/leadwires/chunk/LoadedChunkTracker.java
@@ -66,9 +66,11 @@ public final class LoadedChunkTracker extends PacketAdapter implements Listener 
 			if (type == PacketType.Play.Server.MAP_CHUNK) {
 				ChunkCoord coord = new ChunkCoord(packet.getIntegers().read(0), packet.getIntegers().read(1));
 
-				if (NMSUtil.getMinorVersion() < 9 && isUnloadPacket(packet)) {
-					unloaded = coord;
-					set.remove(coord);
+				if (NMSUtil.getMinorVersion() < 9) {
+					if (isUnloadPacket(packet)) {
+						unloaded = coord;
+						set.remove(coord);
+					}
 				} else {
 					loaded = Collections.singletonList(coord);
 					set.add(coord);
@@ -86,7 +88,7 @@ public final class LoadedChunkTracker extends PacketAdapter implements Listener 
 				set.clear();
 			} else {
 		                ChunkCoord coord;
-		                if (NMSUtil.getMinorVersion() >= 20 && NMSUtil.getReleaseVersion() > 1) {
+				if ((NMSUtil.getMinorVersion() >= 20 && NMSUtil.getReleaseVersion() > 1) || NMSUtil.getMinorVersion() >= 21) {
 		                    coord = new ChunkCoord(packet.getStructures().read(0).getIntegers().read(0), packet.getStructures().read(0).getIntegers().read(1));
 		                } else {
 		                    coord = new ChunkCoord(packet.getIntegers().read(0), packet.getIntegers().read(1));

--- a/src/main/java/me/saharnooby/plugins/leadwires/tracker/ProtocolUtil.java
+++ b/src/main/java/me/saharnooby/plugins/leadwires/tracker/ProtocolUtil.java
@@ -10,6 +10,7 @@ import lombok.NonNull;
 import me.saharnooby.plugins.leadwires.util.NMSUtil;
 import me.saharnooby.plugins.leadwires.wire.Vector;
 import me.saharnooby.plugins.leadwires.wire.Wire;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -40,7 +41,12 @@ public final class ProtocolUtil {
 				PacketType.Play.Server.SPAWN_ENTITY_LIVING;
 		PacketContainer spawn = ProtocolLibrary.getProtocolManager().createPacket(packetType);
 		spawn.getIntegers().write(0, id);
-		spawn.getIntegers().write(1, SILVERFISH_ID);
+
+		if ((NMSUtil.getMinorVersion() >= 20 && NMSUtil.getReleaseVersion() > 4) || NMSUtil.getMinorVersion() >= 21) {
+			spawn.getEntityTypeModifier().write(0, EntityType.SILVERFISH);
+		} else {
+			spawn.getIntegers().write(1, SILVERFISH_ID);
+		}
 
 		if (NMSUtil.getMinorVersion() < 9) {
 			spawn.getIntegers().write(2, (int) (loc.getX() * 32.0D));

--- a/src/main/java/me/saharnooby/plugins/leadwires/tracker/TrackerUtil.java
+++ b/src/main/java/me/saharnooby/plugins/leadwires/tracker/TrackerUtil.java
@@ -18,7 +18,10 @@ public final class TrackerUtil {
 	private static final Vector HOLDER_OFFSET;
 
 	static {
-		if (NMSUtil.getMinorVersion() >= 19) {
+		if (NMSUtil.getMinorVersion() >= 21) {
+			ATTACHED_OFFSET = new Vector(0, 0, -0.15625);
+			HOLDER_OFFSET = new Vector(0, 0, 0);
+		} else if (NMSUtil.getMinorVersion() >= 19) {
 			ATTACHED_OFFSET = new Vector(0, -0.7, -0.15625);
 			HOLDER_OFFSET = new Vector(0, -0.5, 0);
 		} else if (NMSUtil.getMinorVersion() >= 17) {

--- a/src/main/java/me/saharnooby/plugins/leadwires/util/NMSUtil.java
+++ b/src/main/java/me/saharnooby/plugins/leadwires/util/NMSUtil.java
@@ -13,20 +13,26 @@ public final class NMSUtil {
 	private static final int RELEASE;
 
 	static {
+
 		String name = Bukkit.getServer().getClass().getName();
 
-		VERSION = name.substring(23, name.lastIndexOf('.'));
+		if (name.equals("org.bukkit.craftbukkit.CraftServer")) {
+			String bukkitVersion = Bukkit.getBukkitVersion(); // z.B. 1.21-R0.1-SNAPSHOT
+			String[] versionParts = bukkitVersion.split("-")[0].split("\\."); // z.B. [1, 21]
 
-		Pattern pattern = Pattern.compile("v1_(\\d{1,2})_R(\\d{1,2})");
-
-		Matcher matcher = pattern.matcher(VERSION);
-
-		if (!matcher.matches()) {
-			throw new IllegalStateException("Invalid server version \"" + VERSION + "\", server class is \"" + name + "\"");
+			VERSION = bukkitVersion.split("-")[0];
+			MINOR = Integer.parseInt(versionParts[1]);
+			RELEASE = versionParts.length > 2 ? Integer.parseInt(versionParts[2]) : 0;
+		} else {
+			VERSION = name.substring(23, name.lastIndexOf('.'));
+			Pattern pattern = Pattern.compile("v1_(\\d{1,2})_R(\\d{1,2})");
+			Matcher matcher = pattern.matcher(VERSION);
+			if (!matcher.matches()) {
+				throw new IllegalStateException("Invalid server version \"" + VERSION + "\", server class is \"" + name + "\"");
+			}
+			MINOR = Integer.parseInt(matcher.group(1));
+			RELEASE = Integer.parseInt(matcher.group(2));
 		}
-
-		MINOR = Integer.parseInt(matcher.group(1));
-		RELEASE = Integer.parseInt(matcher.group(2));
 	}
 
 	/**

--- a/src/main/java/me/saharnooby/plugins/leadwires/util/NMSUtil.java
+++ b/src/main/java/me/saharnooby/plugins/leadwires/util/NMSUtil.java
@@ -17,8 +17,10 @@ public final class NMSUtil {
 		String name = Bukkit.getServer().getClass().getName();
 
 		if (name.equals("org.bukkit.craftbukkit.CraftServer")) {
-			String bukkitVersion = Bukkit.getBukkitVersion(); // z.B. 1.21-R0.1-SNAPSHOT
-			String[] versionParts = bukkitVersion.split("-")[0].split("\\."); // z.B. [1, 21]
+			// Example: "1.21-R0.1-SNAPSHOT"
+			String bukkitVersion = Bukkit.getBukkitVersion();
+			// Example: ["1", "21"]
+			String[] versionParts = bukkitVersion.split("-")[0].split("\\.");
 
 			VERSION = bukkitVersion.split("-")[0];
 			MINOR = Integer.parseInt(versionParts[1]);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: LeadWires
-version: '1.1.10'
+version: '1.1.11'
 website: 'https://www.spigotmc.org/resources/leadwires.76515/'
 author: saharNooby
 main: me.saharnooby.plugins.leadwires.LeadWires


### PR DESCRIPTION
Hi,
I have implemented all the necessary changes for version 1.21. Unfortunately, so much has changed that you have to be careful which ProtocolLib version you use.

Up to and including 1.20.4 you have to use ProtocolLib 5.2.0. From 1.20.6 you have to use the latest dev build (5.3.0)

Oh, and I failed in the commit message with the version xD

I have tested Minecraft versions 1.19.4, 1.20.1, 1.20.4, 1.20.6 and 1.21
